### PR TITLE
Replace bitnami/kafka with soldevelo/kafka (free alternative)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   kafka:
-    image: 'bitnami/kafka:latest'
+    image: 'soldevelo/kafka:latest'
     ports:
       - '9094:9094'
     networks:


### PR DESCRIPTION
I suggest this change because the Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.

The Soldevelo Kafka image is a drop-in replacement that remains fully compatible with Bitnami's configuration and environment variables. It's actively maintained and provides the same functionality without licensing restrictions.

If you're using Helm charts, Soldevelo also provides Kafka Helm charts as an alternative to Bitnami's charts.
